### PR TITLE
react@0.14, react@15 testing, demo upgrade and lodash moved to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,21 +9,24 @@
     "umd"
   ],
   "scripts": {
-    "build": "nwb build",
+    "build": "npm run build:react:15",
+    "build:react:14": "npm run test:react:14 && nwb build",
+    "build:react:15": "npm run test:react:15 && nwb build",
     "clean": "nwb clean",
     "start": "nwb serve",
-    "test": "nwb test",
+    "test": "npm run test:react:14 && npm run test:react:15",
+    "test:react:14": "npm i react@^0.14 react-dom@^0.14 && nwb test",
+    "test:react:15": "npm i react@^15 react-dom@^15 && nwb test",
     "test:watch": "nwb test --server"
   },
-  "dependencies": {},
+  "dependencies": {
+    "lodash": "^4.12.0"
+  },
   "peerDependencies": {
-    "react": "^15.0 || 0.14.x"
+    "react": ">= 0.14"
   },
   "devDependencies": {
-    "lodash": "4.12.0",
-    "nwb": "0.9.x",
-    "react": "0.14.x",
-    "react-dom": "0.14.x"
+    "nwb": "^0.9.x"
   },
   "author": "Gabe Scholz",
   "license": "MIT",


### PR DESCRIPTION

moved react and react-dom to peer dependencies.

- we now say we expect react@>=0.14 in peer dependencies
- we now test against both react@0.14 and react@15 in one test command for travis.
- we now use react@15 for the demo
- we now have the react@0.14 demo available in the ```npm run build:react:14```

inspired by how react is handled in these projects (typeahead was updated by me also)
https://github.com/airbnb/enzyme
https://github.com/fmoo/react-typeahead/blob/master/package.json#L64