### PR TITLE
updated README to exclude package from production build

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ A function that monkey patches React and notifies you in the console when unnece
 
 ```js
 import React from 'react'
-import {whyDidYouUpdate} from 'why-did-you-update'
 
 if (process.env.NODE_ENV !== 'production') {
+  const {whyDidYouUpdate} = require('why-did-you-update')
   whyDidYouUpdate(React)
 }
 ```


### PR DESCRIPTION
If you import this package it will be included (but unused) in you production build. Moved import to require inside of the environment check in the example.