### PR TITLE
Ignore multiple components by defining an array of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,24 @@ A function that monkey patches React and notifies you in the console when **pote
 ### How to
 
 ```js
-import React from 'react'
-import {whyDidYouUpdate} from 'why-did-you-update'
+import React from 'react';
+import {whyDidYouUpdate} from 'why-did-you-update';
 
 if (process.env.NODE_ENV !== 'production') {
-  whyDidYouUpdate(React)
+  whyDidYouUpdate(React);
 }
 ```
 
 You can include or exclude components by their displayName with the include and exclude options
 
 ```js
-whyDidYouUpdate(React, { include: /^pure/, exclude: /^Connect/ })
+whyDidYouUpdate(React, { include: /^pure/, exclude: /^Connect/ });
+```
+
+You can exclude multiple components by their displayName using an array. Note: this only works with strings for now
+
+```js
+whyDidYouUpdate(React, { exclude: ['Connect', 'DevTools']});
 ```
 
 ### Credit

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "why-did-you-update",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Patch React to discover unnecessary re-renders",
   "main": "lib/index.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import {shouldInclude} from './shouldInclude'
 function createComponentDidUpdate (opts) {
   return function componentDidUpdate (prevProps, prevState) {
     const displayName = getDisplayName(this)
-
+  
     if (!shouldInclude(displayName, opts)) {
       return
     }

--- a/src/normalizeOptions.js
+++ b/src/normalizeOptions.js
@@ -1,4 +1,5 @@
 import _isString from 'lodash/isString'
+import _isArray from 'lodash/isArray'
 import _isRegExp from 'lodash/isRegExp'
 
 export const normalizeOptions = (opts = {}) => {
@@ -10,7 +11,9 @@ export const normalizeOptions = (opts = {}) => {
     include = /./
   }
 
-  if (_isString(exclude)) {
+  if (_isArray(exclude)) {
+    exclude = exclude;
+  } else if (_isString(exclude)) {
     exclude = new RegExp(exclude)
   } else if (!_isRegExp(exclude)) {
     exclude = /[^a-zA-Z0-9]/

--- a/src/normalizeOptions.js
+++ b/src/normalizeOptions.js
@@ -12,7 +12,13 @@ export const normalizeOptions = (opts = {}) => {
   }
 
   if (_isArray(exclude)) {
-    exclude = exclude;
+    for (let i = 0; i < exclude.length; i++) {
+      if (_isString(exclude[i])) {
+        exclude[i] = new RegExp(exclude[i]);
+      } else if (!_isRegExp(exclude[i])){
+        exclude[i] = /[^a-zA-Z0-9]/;
+      }
+    }
   } else if (_isString(exclude)) {
     exclude = new RegExp(exclude)
   } else if (!_isRegExp(exclude)) {

--- a/src/shouldInclude.js
+++ b/src/shouldInclude.js
@@ -1,8 +1,25 @@
 import _isFunction from 'lodash/isFunction'
+import _isArray from 'lodash/isArray'
 
 export const shouldInclude = (displayName, {include, exclude}) => {
-  let isIncluded = include.test(displayName)
-  let isExcluded = exclude.test(displayName)
+
+  let isIncluded;
+  let isExcluded;
+
+  if (_isArray(exclude)) {
+    isExcluded = false;
+    let i = 0;
+    for (; i < exclude.length; i++) {
+      if (exclude[i] === displayName) {
+        isExcluded = true;
+        break;
+      }
+    }
+  } else {
+    isExcluded = exclude.test(displayName)
+  }
+
+  isIncluded = include.test(displayName)
 
   return isIncluded && !isExcluded
 }

--- a/src/shouldInclude.js
+++ b/src/shouldInclude.js
@@ -8,9 +8,9 @@ export const shouldInclude = (displayName, {include, exclude}) => {
 
   if (_isArray(exclude)) {
     isExcluded = false;
-    let i = 0;
-    for (; i < exclude.length; i++) {
-      if (exclude[i] === displayName) {
+    for (let i = 0; i < exclude.length; i++) {
+      const item = exclude[i];
+      if (item.test(displayName)) {
         isExcluded = true;
         break;
       }

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -145,7 +145,21 @@ describe(`whyDidYouUpdate`, () => {
     render(<YetAnotherStub a={1} />, node)
     render(<YetAnotherStub a={1} />, node)
 
-    assert.equal(warnStore.entries.length, 1)
+    assert.equal(warnStore.entries.length, 0)
+  })
+
+  it(`can ignore multiple names using a regexp`, () => {
+    React.__WHY_DID_YOU_UPDATE_RESTORE_FN__()
+    whyDidYouUpdate(React, {exclude: [/Stub/, /AnotherStub/]})
+
+    render(<Stub a={1} />, node)
+    render(<Stub a={1} />, node)
+    render(<AnotherStub a={1} />, node)
+    render(<AnotherStub a={1} />, node)
+    render(<YetAnotherStub a={1} />, node)
+    render(<YetAnotherStub a={1} />, node)
+
+    assert.equal(warnStore.entries.length, 0)
   })
 
   it(`can include only certain names using a regexp`, () => {

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -26,6 +26,16 @@ class Stub extends React.Component {
     return <noscript />
   }
 }
+class AnotherStub extends React.Component {
+  render () {
+    return <noscript />
+  }
+}
+class YetAnotherStub extends React.Component {
+  render () {
+    return <noscript />
+  }
+}
 
 describe(`whyDidYouUpdate`, () => {
   let node
@@ -122,6 +132,20 @@ describe(`whyDidYouUpdate`, () => {
     render(<Stub a={1} />, node)
 
     assert.equal(warnStore.entries.length, 0)
+  })
+
+  it(`can ignore multiple names using a string`, () => {
+    React.__WHY_DID_YOU_UPDATE_RESTORE_FN__()
+    whyDidYouUpdate(React, {exclude: ['Stub', 'AnotherStub']})
+
+    render(<Stub a={1} />, node)
+    render(<Stub a={1} />, node)
+    render(<AnotherStub a={1} />, node)
+    render(<AnotherStub a={1} />, node)
+    render(<YetAnotherStub a={1} />, node)
+    render(<YetAnotherStub a={1} />, node)
+
+    assert.equal(warnStore.entries.length, 1)
   })
 
   it(`can include only certain names using a regexp`, () => {


### PR DESCRIPTION
Since my project threw a lot of errors made by things out of my control (DevTools, DockMonitor, IntlProvider and others) I wanted the option to ignore multiple components. This pull request adds that feature, but only for arrays where you define the componentNames as strings. Not sure how to implement regex as well.