### PR TITLE
Use lodash-webpack-plugin to save 35% on the minified+gzipped build.

### DIFF
--- a/nwb.config.js
+++ b/nwb.config.js
@@ -1,3 +1,5 @@
+var LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
+
 module.exports = {
   type: 'react-component',
   build: {
@@ -7,5 +9,12 @@ module.exports = {
     global: 'WhyDidYouUpdate',
     jsNext: false,
     umd: true
+  },
+  webpack: {
+    extra: {
+      plugins: [
+        new LodashModuleReplacementPlugin
+      ]
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,12 +17,13 @@
     "release:patch": "nwb build && npm version patch && npm publish"
   },
   "dependencies": {
-    "lodash": "4.12.0"
+    "lodash": "^4.13.1"
   },
   "peerDependencies": {
     "react": "^15.0 || 0.14.x"
   },
   "devDependencies": {
+    "lodash-webpack-plugin": "^0.8.1",
     "nwb": "0.9.x",
     "react": "0.14.x",
     "react-dom": "0.14.x"


### PR DESCRIPTION
Using [lodash-webpack-plugin](https://github.com/lodash/lodash-webpack-plugin) to reduce the build size of lodash deps the new size is 4.7 kB 😸 